### PR TITLE
Add DevContainer (GitHub codespaces support and convenience commands)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Our own public container that we've published to assist with this project
-FROM ghcr.io/seankilleen/blog-in-a-box-container:ruby2.7.4-node21
+FROM ghcr.io/seankilleen/blog-in-a-box-container:ghpages232-node22
 
 VOLUME /docs
 WORKDIR /docs

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# Our own public container that we've published to assist with this project
+FROM ghcr.io/seankilleen/blog-in-a-box-container:ruby2.7.4-node21
+
+VOLUME /docs
+WORKDIR /docs
+
+COPY aliases.sh /etc/profile.d/alias.sh
+
+# Coverts CRLF based files (such as those on windows devices) to LF line endings for container
+RUN dos2unix /etc/profile.d/alias.sh
+
+RUN cat /etc/profile.d/alias.sh >> ~/.bashrc
+
+EXPOSE 4000

--- a/.devcontainer/aliases.sh
+++ b/.devcontainer/aliases.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# We get the first workspace, because there should only be one
+# This is so that when someone updates their devcontainer name, it doesn't get screwed up
+first_workspace="$(cd /workspaces && ls | head -1)"
+alias gotoworkspace="cd /workspaces/$first_workspace"
+alias localdev="gotoworkspace && bundle exec jekyll serve --future --force_polling --livereload"
+alias build="gotoworkspace && bundle exec jekyll build"
+alias serve="gotoworkspace && bundle exec jekyll serve --future --force_polling --livereload"
+alias spellcheck="gotoworkspace && cspell --no-progress --config cSpell.json **/*.md"
+alias lint="gotoworkspace && markdownlint-cli2 --config .markdownlint-cli2.jsonc **/*.md"
+alias lintfix="gotoworkspace && markdownlint-cli2 --fix --config .markdownlint-cli2.jsonc **/*.md"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "SeanKilleen.com dev container",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "forwardPorts": [
+        4000
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "streetsidesoftware.code-spell-checker",
+                "oderwat.indent-rainbow",
+                "mdickin.markdown-shortcuts",
+                "davidanson.vscode-markdownlint",
+                "redhat.vscode-yaml",
+                "github.vscode-pull-request-github",
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    },
+    "postStartCommand": "bundle install"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "SeanKilleen.com dev container",
+    "name": "Merill.net dev container",
     "build": {
         "dockerfile": "Dockerfile"
     },


### PR DESCRIPTION
Makes it easier for folks (and maintainers!) to drop into a web-based or local vscode instance and have everything you need to build & run the site locally.

This container pulls from <https://github.com/SeanKilleen/blog-in-a-box-container/> , which I maintain.

In addition to a devcontainer, it adds several shortcuts for ease of use:

* `localdev` - serves with livereload
* `build` and `serve`
* `spellcheck` - runs cSpell (once my follow-up PR is complete to set up the config)
* `lint` - runs markdown linting (once my follow-up PR is complete to set up the config)
* `lintfix` runs markdown linting with fixes. (once my follow-up PR is complete to set up the config)